### PR TITLE
Allow camera injection

### DIFF
--- a/Src/Medicine.CodeGen/InjectionPostProcessor.cs
+++ b/Src/Medicine.CodeGen/InjectionPostProcessor.cs
@@ -181,7 +181,7 @@ namespace Medicine
                     if (attribute.Is<Inject.All>())
                     {
                         if (!isInterface && !isMonoBehaviour && !isScriptableObject)
-                            throw new MedicineError($"Type of property with [Inject.Single] needs to be an array of MonoBehaviours, ScriptableObjects, or interfaces.", property);
+                            throw new MedicineError($"Type of property with {attribute.GetName()} needs to be an array of MonoBehaviours, ScriptableObjects, or interfaces.", property);
 
                         if (!isArray)
                             throw new MedicineError($"Type of property with {attribute.GetName()} needs to be an array.", property);

--- a/Src/Medicine.CodeGen/InjectionPostProcessor.cs
+++ b/Src/Medicine.CodeGen/InjectionPostProcessor.cs
@@ -194,7 +194,7 @@ namespace Medicine
                         continue;
                     }
 
-                    if (!isInterface && !isComponent)
+                    if (!isInterface && !isComponent && !isCamera)
                         throw new MedicineError($"Type of property with {attribute.GetName()} needs to be a component or an interface.", property);
 
                     if (type.Attributes.HasFlagNonAlloc(TypeAttributes.Abstract | TypeAttributes.Sealed))


### PR DESCRIPTION
A tiny modification for `InjectionPostProcessor` allowing `Inject` attributes (all but `Inject.All`) to be used on properties of type UnityEngine.Camera. It doesn't change the special handling of Camera.main injection.
