### PR TITLE
Prepend migrated statements instead of appending in VersionMigrationFixProvider

### DIFF
--- a/Medicine.SourceGenerator~/CodeFixes/VersionMigrationFixProvider.cs
+++ b/Medicine.SourceGenerator~/CodeFixes/VersionMigrationFixProvider.cs
@@ -177,7 +177,11 @@ public sealed class VersionMigrationFixProvider : CodeFixProvider
                     .WithAdditionalAnnotations(Formatter.Annotation);
             }
 
-            methodDecl = methodDecl.WithBody(methodDecl.Body?.AddStatements((StatementSyntax)propAssign));
+
+            methodDecl = methodDecl.WithBody(methodDecl.Body is null ?
+                                                 SyntaxFactory.Block((StatementSyntax)propAssign) :
+                                                 SyntaxFactory.Block(methodDecl.Body.Statements
+                                                                               .Prepend((StatementSyntax)propAssign)));
 
             editor.ReplaceNode(originalMethod, methodDecl);
         }


### PR DESCRIPTION
## Motivation

Some initialization statements in `Awake` depend on injected objects. 
Currently, migrated statements are added to the end of the `Awake` block, which may introduce null references to statements above it. 
We can address this issue by prepending the added statements to the front of the `Awake` method.

<img width="1093" height="219" alt="image" src="https://github.com/user-attachments/assets/91bec9bd-c6c5-4229-8bfe-0917a7df27aa" />

<img width="855" height="156" alt="image" src="https://github.com/user-attachments/assets/c614e8f1-9482-4575-8072-99c77279e4c8" />
